### PR TITLE
Calling toast repeatedly causes the application to crash

### DIFF
--- a/Toast/HRToast+UIView.swift
+++ b/Toast/HRToast+UIView.swift
@@ -99,9 +99,10 @@ extension UIView {
     func showToast(#toast: UIView, duration: Double, position: AnyObject) {
         var existToast = objc_getAssociatedObject(self, &HRToastView) as UIView?
         if existToast != nil {
-            var timer = objc_getAssociatedObject(existToast, &HRToastTimer) as NSTimer
-            timer.invalidate();
-            self.hideToast(toast: existToast!, force: false);
+            if let timer = objc_getAssociatedObject(existToast, &HRToastTimer) as? NSTimer {
+                timer.invalidate();
+                self.hideToast(toast: existToast!, force: false);
+            }
         }
         
         toast.center = self.centerPointForPosition(position, toast: toast)


### PR DESCRIPTION
This checks if the object is an NSTimer before casting it as calling toast repeatedly sometime causes the function to result a nil value.