### PR TITLE
Added check to makeToastActivity to remove existing non activity toasts ...

### DIFF
--- a/Toast/HRToast+UIView.swift
+++ b/Toast/HRToast+UIView.swift
@@ -138,6 +138,14 @@ extension UIView {
     }
     
     func makeToastActivity(position pos: AnyObject, message msg: String = "") {
+		var existToast = objc_getAssociatedObject(self, &HRToastView) as! UIView?
+		        if existToast != nil {
+		            if let timer = objc_getAssociatedObject(existToast, &HRToastTimer) as? NSTimer {
+		                timer.invalidate();
+		                self.hideToast(toast: existToast!, force: false);
+		            }
+		        }
+				
         var existingActivityView: UIView? = objc_getAssociatedObject(self, &HRToastActivityView) as? UIView
         if existingActivityView != nil { return }
         


### PR DESCRIPTION
When creating a Toast with Activity if there is an active 'standard' toast it does not first clear that, have implemented same code & behaviour as makeToast to check and clear any existing toast first.