### PR TITLE
Adjust z position of the toast

### DIFF
--- a/SwiftToastDemo/Toast/HRToast+UIView.swift
+++ b/SwiftToastDemo/Toast/HRToast+UIView.swift
@@ -445,6 +445,9 @@ extension UIView {
             wrapperView.addSubview(imageView!)
         }
         
+        // show it on top of all views
+        wrapperView.layer.zPosition = 5
+        
         return wrapperView
     }
     


### PR DESCRIPTION
Otherwise, results in the toast sometimes being drawn behind tables/rows/sections (or any view) etc., in the z direction

Eg: 
![sampletoastissue](https://cloud.githubusercontent.com/assets/1938607/18284314/112c1fc2-742f-11e6-8ec1-550e36b0cb14.jpg)
